### PR TITLE
docs: align READMEs — registry links + section typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ unicefData-dev/
 
 | Platform | README | Changelog | Version |
 |----------|--------|-----------|---------|
-| **R** | [r/README.md](r/README.md) | [r/NEWS.md](r/NEWS.md) | 2.4.0 |
+| **R** | [r/README.md](r/README.md) | [r/NEWS.md](r/NEWS.md) | 2.4.0 ([CRAN](https://cran.r-project.org/package=unicefData)) |
 | **Python** | [python/README.md](python/README.md) | [python/CHANGELOG.md](python/CHANGELOG.md) | 2.4.1 ([PyPI](https://pypi.org/project/unicefdata/)) |
-| **Stata** | [stata/README.md](stata/README.md) | [stata/CHANGELOG.md](stata/CHANGELOG.md) | 2.4.0 |
+| **Stata** | [stata/README.md](stata/README.md) | [stata/CHANGELOG.md](stata/CHANGELOG.md) | 2.4.0 ([SSC](https://ideas.repec.org/c/boc/bocode/s459598.html)) |
 
 ## Repository Documentation
 

--- a/python/README.md
+++ b/python/README.md
@@ -76,7 +76,7 @@ print(df.attrs["nearest_year"])     # 2019
 
 See [CHANGELOG.md](CHANGELOG.md) for complete details.
 
-## What's New in 2.3.2
+## What's New in 2.2.0
 
 - **328+ automated tests** across 11 test families with deterministic fixtures
 - **Full CI matrix**: Python 3.9–3.12 on Ubuntu / macOS / Windows


### PR DESCRIPTION
Merges README alignment fix from develop to main.